### PR TITLE
fix: nested if wrong scope jump bug fixed

### DIFF
--- a/src/da.h
+++ b/src/da.h
@@ -88,3 +88,10 @@ do { \
 #define DA_GET(da, index) ((da).items[index])
 
 #define DA_GET_LAST(da) ((da).items[(da).count -1])
+
+#define DA_FREE(da) \
+do { \
+    if((da).items != NULL){ \
+        free((da).items); \
+    } \
+} while(0)


### PR DESCRIPTION
**code**:
```
true
if
  true
  if
    true
    if
      "3-text"
    end
    "2-text"
  else
    "2-false"
  end
  "1-text"
else
  "1-false"
end
dump

```

**before**:
![Screenshot_20240608_132418](https://github.com/saracalihan/ctack/assets/56413673/b9150137-27ba-4e54-8a7f-f47081ac1901)

**after**:
![Screenshot_20240608_132658](https://github.com/saracalihan/ctack/assets/56413673/d0ad8aa4-f665-4f2c-b601-12a8f124f66a)


close #13